### PR TITLE
[Compatibility] Trigger driver CREATE OR REPLACE command

### DIFF
--- a/drivers/trigger/queries.go
+++ b/drivers/trigger/queries.go
@@ -109,6 +109,7 @@ func (d *Driver) getCreateTriggerSqlForOperation(listenerUid string, l *flash.Li
 		}
 
 		if rawConditionSql == "" {
+
 			statement = fmt.Sprintf(`
 				CREATE OR REPLACE FUNCTION "%s"."%s"() RETURNS trigger AS $trigger$
 				BEGIN 
@@ -132,11 +133,13 @@ func (d *Driver) getCreateTriggerSqlForOperation(listenerUid string, l *flash.Li
 	}
 
 	if operation != "TRUNCATE" {
+		// Keep drop + create instead of 'create or replace' for Pgsql13 compatibility
 		statement += fmt.Sprintf(`
 			DROP TRIGGER IF EXISTS "%s" ON %s;
 			CREATE TRIGGER "%s" AFTER %s ON %s FOR EACH ROW EXECUTE PROCEDURE "%s"."%s"();`,
 			triggerName, d.sanitizeTableName(l.Table), triggerName, operation, d.sanitizeTableName(l.Table), d.Config.Schema, triggerFnName)
 	} else {
+		// Keep drop + create instead of 'create or replace' for Pgsql13 compatibility
 		statement += fmt.Sprintf(`
 			DROP TRIGGER IF EXISTS "%s" ON %s;
 			CREATE TRIGGER "%s" BEFORE TRUNCATE ON %s FOR EACH STATEMENT EXECUTE PROCEDURE "%s"."%s"();`,

--- a/drivers/trigger/queries.go
+++ b/drivers/trigger/queries.go
@@ -133,12 +133,14 @@ func (d *Driver) getCreateTriggerSqlForOperation(listenerUid string, l *flash.Li
 
 	if operation != "TRUNCATE" {
 		statement += fmt.Sprintf(`
-			CREATE OR REPLACE TRIGGER "%s" AFTER %s ON %s FOR EACH ROW EXECUTE PROCEDURE "%s"."%s"();`,
-			triggerName, operation, d.sanitizeTableName(l.Table), d.Config.Schema, triggerFnName)
+			DROP TRIGGER IF EXISTS "%s" ON %s;
+			CREATE TRIGGER "%s" AFTER %s ON %s FOR EACH ROW EXECUTE PROCEDURE "%s"."%s"();`,
+			triggerName, d.sanitizeTableName(l.Table), triggerName, operation, d.sanitizeTableName(l.Table), d.Config.Schema, triggerFnName)
 	} else {
 		statement += fmt.Sprintf(`
-			CREATE OR REPLACE TRIGGER "%s" BEFORE TRUNCATE ON %s FOR EACH STATEMENT EXECUTE PROCEDURE "%s"."%s"();`,
-			triggerName, d.sanitizeTableName(l.Table), d.Config.Schema, triggerFnName)
+			DROP TRIGGER IF EXISTS "%s" ON %s;
+			CREATE TRIGGER "%s" BEFORE TRUNCATE ON %s FOR EACH STATEMENT EXECUTE PROCEDURE "%s"."%s"();`,
+			triggerName, d.sanitizeTableName(l.Table), triggerName, d.sanitizeTableName(l.Table), d.Config.Schema, triggerFnName)
 	}
 
 	return statement, eventName, nil


### PR DESCRIPTION
When initing listeners by trigger driver, driver is going to execute `CREATE OR REPLACE FUNCTION` and `CREATE OR REPLACE TRIGGER`.
`OR REPLACE` command is supported by postgresql since 14.
Use `DROP TRIGGER IF EXISTS` and `CREATE TRIGGER` instead of `CREATE OR REPLACE TRIGGER`